### PR TITLE
color disparity

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -79,7 +79,7 @@
 	}
 
 	:global(html) {
-		background-color: var(--rich-black);
+		background-color: var(--rich-black-fogra);
 		color: #fff;
 		font-family: 'Inter var';
 		font-feature-settings: 'ss01','ss02','ss03','cv01','tnum';


### PR DESCRIPTION
html background color is different than the app background color, which creates a visible distinction on bigger screens.
![telegram-cloud-photo-size-1-5114185488729746004-x](https://user-images.githubusercontent.com/28722660/136487347-02437ff0-e7fa-4fd5-85b7-de667b75b0f8.jpg)
![telegram-cloud-photo-size-1-5114185488729745999-x](https://user-images.githubusercontent.com/28722660/136487373-0e0e8358-0680-490e-aa2d-2ccf27e9c3b1.jpg)
